### PR TITLE
Fix kd-tree empty initialization and backend selection

### DIFF
--- a/include/posets/downsets/vector_or_kdtree_backed.hh
+++ b/include/posets/downsets/vector_or_kdtree_backed.hh
@@ -38,9 +38,9 @@ namespace posets::downsets {
       template <Vector V2>
       friend std::ostream& operator<< (std::ostream& os, const vector_or_kdtree_backed<V2>& f);
 
-      size_t dim () {
-        // TODO  This is a terrible name for this function.
-        return get_backing_vector ().size ();
+      size_t vector_dim () const {
+        const auto& backing = get_backing_vector ();
+        return backing.empty () ? 0 : backing[0].size ();
       }
 
       void boolop_with (vector_or_kdtree_backed&& other, bool inter = false) {
@@ -91,7 +91,7 @@ namespace posets::downsets {
           }
           else {
             m = this->size ();
-            n = this->size ();
+            n = other.size ();
           }
           if (static_cast<double> (n) < exp (static_cast<double> (m))) {
             if (inter)
@@ -116,7 +116,7 @@ namespace posets::downsets {
         // list but it satisfies the condition for it to be upgraded to a
         // kd-tree
         const size_t m = this->size ();
-        const size_t dim = this->dim ();
+        const size_t dim = this->vector_dim ();
         data_do (std::cout << "|VEKD: downset_size=" << dim << "," << m << "|" << std::endl);
         if (this->kdtree == nullptr and KD_THRESH (m, dim)) {
           this->kdtree =

--- a/include/posets/downsets/vector_or_kdtree_backed.hh
+++ b/include/posets/downsets/vector_or_kdtree_backed.hh
@@ -38,7 +38,7 @@ namespace posets::downsets {
       template <Vector V2>
       friend std::ostream& operator<< (std::ostream& os, const vector_or_kdtree_backed<V2>& f);
 
-      size_t vector_dim () const {
+      [[nodiscard]] size_t vector_dim () const {
         const auto& backing = get_backing_vector ();
         return backing.empty () ? 0 : backing[0].size ();
       }

--- a/include/posets/utils/kdtree.hh
+++ b/include/posets/utils/kdtree.hh
@@ -1,8 +1,8 @@
 #pragma once
 
 #include <algorithm>
+#include <bit>
 #include <cassert>
-#include <cmath>
 #include <cstdint>
 #include <iostream>
 #include <limits>
@@ -66,6 +66,10 @@ namespace posets::utils {
         return not bound.has_value () or bound.value () < value;
       }
 
+      static size_t tree_capacity (size_t element_count) {
+        return size_t {4} * std::bit_floor (element_count);
+      }
+
       // NOLINTBEGIN(misc-no-recursion)
       /*
        * This is one of the only interesting parts of the code: building the
@@ -81,9 +85,7 @@ namespace posets::utils {
         // sanity checks
         assert (this->tree != nullptr);
         assert (this->dim <= std::numeric_limits<axis_type>::max ());
-        assert (std::cmp_greater (
-            size_t {4} << static_cast<size_t> (std::floor (std::log2 (this->vector_set.size ()))),
-            result));
+        assert (std::cmp_greater (tree_capacity (this->vector_set.size ()), result));
         assert (std::cmp_equal (std::distance (begin_it, end_it), length));
         assert (length > 0);
         assert (axis < this->dim);
@@ -147,9 +149,7 @@ namespace posets::utils {
                                 lower_bound_type* lbounds, size_t dims_to_dom) const {
         // sanity checks
         assert (this->tree != nullptr);
-        assert (std::cmp_greater (
-            size_t {4} << static_cast<size_t> (std::floor (std::log2 (this->vector_set.size ()))),
-            node_idx));
+        assert (std::cmp_greater (tree_capacity (this->vector_set.size ()), node_idx));
         assert (dims_to_dom > 0);
 
         // from index to node pointer
@@ -199,18 +199,18 @@ namespace posets::utils {
       // NOTE: this works for any collection of vectors, not even set assumed
       template <std::ranges::input_range R, class Proj = std::identity>
       void relabel_tree (R&& elements, Proj proj = {}) {
+        assert (elements.size () > 0);
         this->dim = (proj (*elements.begin ()).size ());
 
         // sanity checks
-        assert (elements.size () > 0);
         assert (this->dim > 0);
         assert (this->dim <= std::numeric_limits<axis_type>::max ());
 
         // Let n be the size of vector_set, the no. of leaves in the tree is
         // 2^{floor(lg(n)) + 1}, so this times 2 is the size of the full
         // binary tree we will be labelling
-        const size_t oldsize = 4 << (size_t) (std::floor (std::log2 (this->vector_set.size ())));
-        const size_t tsize = 4 << (size_t) (std::floor (std::log2 (elements.size ())));
+        const size_t oldsize = tree_capacity (this->vector_set.size ());
+        const size_t tsize = tree_capacity (elements.size ());
 
         // moving the given elements to the internal data structure
         std::vector<V> newset;
@@ -228,9 +228,7 @@ namespace posets::utils {
         // NOLINTBEGIN(boost-use-ranges)
         std::iota (points.begin (), points.end (), 0);
         // NOLINTEND(boost-use-ranges)
-        if (this->tree == nullptr)
-          this->tree = new kdtree_node[tsize];
-        if (this->tree != nullptr and oldsize < tsize) {
+        if (this->tree == nullptr or oldsize < tsize) {
           delete[] this->tree;
           this->tree = new kdtree_node[tsize];
         }
@@ -246,10 +244,11 @@ namespace posets::utils {
         assert (dim <= std::numeric_limits<axis_type>::max ());
       }
 
-      kdtree (size_t dim, size_t initsize) : dim (dim) {
+      kdtree (size_t dim, size_t initsize) : dim (dim), tree (nullptr) {
         assert (dim <= std::numeric_limits<axis_type>::max ());
-        const size_t tsize = 4 << (size_t) (std::floor (std::log2 (initsize)));
-        this->tree = new kdtree_node[tsize];
+        const size_t tsize = tree_capacity (initsize);
+        if (tsize > 0)
+          this->tree = new kdtree_node[tsize];
       }
 
       template <std::ranges::input_range R, class Proj = std::identity>

--- a/tests/reducetests.cc
+++ b/tests/reducetests.cc
@@ -32,11 +32,11 @@ void check_reduce (const std::vector<std::vector<value_type>>& raw) {
     assert (keys[i] == posets::utils::sum_key (reduced[i]));
   std::vector<size_t> expected;
   for (size_t i = 0; i < raw.size (); ++i) {
-    V candidate (std::span<const value_type> (raw[i]));
+    V candidate {std::span<const value_type> (raw[i])};
     bool dominated = false;
     bool duplicate_before = false;
     for (size_t j = 0; j < raw.size (); ++j) {
-      V other (std::span<const value_type> (raw[j]));
+      V other {std::span<const value_type> (raw[j])};
       auto po = candidate.partial_order (other);
       if (po.leq () and not po.geq ())
         dominated = true;
@@ -48,7 +48,7 @@ void check_reduce (const std::vector<std::vector<value_type>>& raw) {
   }
   assert (reduced.size () == expected.size ());
   for (size_t i : expected) {
-    V value (std::span<const value_type> (raw[i]));
+    V value {std::span<const value_type> (raw[i])};
     bool found = false;
     for (const auto& kept : reduced)
       found or_eq kept == value;
@@ -103,4 +103,17 @@ int main () {
   assert (reduced.size () == 1);
   assert (reduced.front () == expected);
   assert (keys == std::vector<long> {9});
+
+  const std::vector<std::vector<value_type>> relabel_raw {
+      {1, 0, 0},
+      {0, 1, 0},
+      {0, 0, 1},
+  };
+  posets::utils::kdtree<with_sum> default_tree;
+  default_tree.relabel_tree (make_vectors<with_sum> (relabel_raw));
+  assert (default_tree.size () == relabel_raw.size ());
+
+  posets::utils::kdtree<with_sum> zero_hint_tree (3, 0);
+  zero_hint_tree.relabel_tree (make_vectors<with_sum> (relabel_raw));
+  assert (zero_hint_tree.size () == relabel_raw.size ());
 }


### PR DESCRIPTION
## Summary

- avoid floating-point `log2(0)` and invalid shifts when relabeling an initially empty kd-tree
- handle a zero initial-size hint without allocating an invalid tree
- correct vector dimension and right-hand size calculations used by `vector_or_kdtree_backed`
- add regressions for default and zero-hint kd-tree relabeling

## Validation

- Posets GCC release suite: 12/12 passed
- Posets Clang UBSan suite (`halt_on_error=1`): 12/12 passed
- Acacia unit suites: 45/45 passed across the four shipping downset backends plus `vector_or_kdtree`
- Acacia optimized `syntcomp21/crit` comparison: no lost instances for `vector_or_kdtree`

The experimental bboxtree pruning work was rejected by its performance gate and is not included.
